### PR TITLE
Minor changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "src/addon/ankniaddonconfig"]
-	path = src/addon/ankniaddonconfig
-	url = https://github.com/BlueGreenMagick/ankiaddonconfig.git
 [submodule "src/addon/ankiaddonconfig"]
 	path = src/addon/ankiaddonconfig
 	url = https://github.com/BlueGreenMagick/ankiaddonconfig.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "src/addon/ankiaddonconfig"]
-	path = src/addon/ankiaddonconfig
-	url = https://github.com/BlueGreenMagick/ankiaddonconfig.git
-[submodule "src/addon/mega"]
-	path = src/addon/mega
-	url = git@github.com:odwyersoftware/mega.py.git

--- a/src/addon/dialog.py
+++ b/src/addon/dialog.py
@@ -23,14 +23,14 @@ class ImportResultDialog(QMessageBox):
             details += "&nbsp;" * (50 - len(details))
         text = f"<h3><b>{title}</b></h3>{details}<br>"
         self.setText(text)
-        self.setTextFormat(Qt.RichText)
+        self.setTextFormat(Qt.TextFormat.RichText)
         self.setDetailedText("\n".join(result.logs))
 
 
 class ImportDialog(QDialog):
 
     def __init__(self) -> None:
-        QDialog.__init__(self, mw, Qt.Window)
+        QDialog.__init__(self, mw, Qt.WindowType.Window)
         self.setWindowTitle("Import Media")
         self.setMinimumWidth(500)
         self.setup()
@@ -44,7 +44,7 @@ class ImportDialog(QDialog):
 
         main_tab = QTabWidget()
         self.main_tab = main_tab
-        main_tab.setFocusPolicy(Qt.StrongFocus)
+        main_tab.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         main_layout.addWidget(main_tab)
         main_layout.addSpacing(10)
 
@@ -76,10 +76,10 @@ class ImportDialog(QDialog):
     def finish_import(self, result: ImportResult) -> None:
         mw.progress.finish()
         if result.success:
-            ImportResultDialog(mw, result).exec_()
+            ImportResultDialog(mw, result).exec()
             self.close()
         else:
-            ImportResultDialog(self, result).exec_()
+            ImportResultDialog(self, result).exec()
             self.tab.update_root_file()
 
     def open_media_dir(self) -> None:

--- a/src/addon/dialog.py
+++ b/src/addon/dialog.py
@@ -12,10 +12,10 @@ class ImportResultDialog(QMessageBox):
         QMessageBox.__init__(self, parent)
         if result.success:
             title = "Import Complete"
-            self.setIcon(QMessageBox.Information)
+            self.setIcon(QMessageBox.Icon.Information)
         else:
             title = "Import Failed"
-            self.setIcon(QMessageBox.Critical)
+            self.setIcon(QMessageBox.Icon.Critical)
         self.setWindowTitle(title)
         details = result.logs[-1]
         if len(details) < 50:

--- a/src/addon/importing.py
+++ b/src/addon/importing.py
@@ -38,7 +38,7 @@ class ImportInfo():
         self.tot_size = self.size
 
     def update_count(self) -> int:
-        """ Returns `curr - prev`, then updates prev to curr """
+        """ Returns `prev - curr`, then updates prev to curr """
         self.diff = self.prev - self.curr
         self.prev = self.curr
         return self.diff

--- a/src/addon/tabs/base.py
+++ b/src/addon/tabs/base.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 def qlabel(text: str) -> QLabel:
     label = QLabel(text)
-    label.setTextInteractionFlags(Qt.TextBrowserInteraction)
+    label.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
     return label
 
 

--- a/src/addon/tabs/local.py
+++ b/src/addon/tabs/local.py
@@ -57,7 +57,7 @@ class LocalTab(ImportTab):
     def file_dialog(self) -> QFileDialog:
         dialog = QFileDialog(self)
         dialog.setNameFilter(self.file_name_filter())
-        dialog.setOption(QFileDialog.ShowDirsOnly, False)
+        dialog.setOption(QFileDialog.Option.ShowDirsOnly, False)
         if is_win or is_lin:
             # Windows directory chooser doesn't display files
             # Some linux directory choosers (Nautilus) don't let you navigate directories
@@ -68,7 +68,7 @@ class LocalTab(ImportTab):
 
     def get_directory(self) -> Optional[str]:
         dialog = self.file_dialog()
-        dialog.setFileMode(QFileDialog.Directory)
+        dialog.setFileMode(QFileDialog.FileMode.Directory)
         if dialog.exec():
             # This can return multiple paths onccasionally. Qt bug?
             if not len(dialog.selectedFiles()) == 1:

--- a/src/addon/tabs/local.py
+++ b/src/addon/tabs/local.py
@@ -60,7 +60,7 @@ class LocalTab(ImportTab):
     def get_directory(self) -> Optional[str]:
         dialog = self.file_dialog()
         dialog.setFileMode(QFileDialog.Directory)
-        if dialog.exec_():
+        if dialog.exec():
             # This can return multiple paths onccasionally. Qt bug?
             if not len(dialog.selectedFiles()) == 1:
                 tooltip("Something went wrong. Please select the folder again.")

--- a/src/addon/tabs/local.py
+++ b/src/addon/tabs/local.py
@@ -1,18 +1,23 @@
 from typing import Optional, TYPE_CHECKING
 
-from anki.utils import isWin
+try:
+    from anki.utils import is_win, is_lin
+except ImportError:
+    from anki.utils import isWin as is_win  # type: ignore
+    from anki.utils import isLin as is_lin  # type: ignore
+
 from aqt.qt import *
 from aqt.utils import tooltip
 import aqt.editor
 
 from ..pathlike.local import LocalRoot
 from .base import ImportTab
+
 if TYPE_CHECKING:
     from .base import ImportDialog
 
 
 class LocalTab(ImportTab):
-
     def __init__(self, dialog: "ImportDialog"):
         self.define_texts()
         ImportTab.__init__(self, dialog)
@@ -24,7 +29,9 @@ class LocalTab(ImportTab):
         self.while_create_rootpath_msg = "Calculating number of files..."
         self.malformed_url_msg = "Invalid Path"
         self.root_not_found_msg = "Folder doesn't exist."
-        self.is_a_file_msg = "This path leads to a file. Please write a path to a folder."
+        self.is_a_file_msg = (
+            "This path leads to a file. Please write a path to a folder."
+        )
 
     def create_root_file(self, url: str) -> LocalRoot:
         return LocalRoot(url)
@@ -51,10 +58,12 @@ class LocalTab(ImportTab):
         dialog = QFileDialog(self)
         dialog.setNameFilter(self.file_name_filter())
         dialog.setOption(QFileDialog.ShowDirsOnly, False)
-        if isWin:
+        if is_win or is_lin:
             # Windows directory chooser doesn't display files
+            # Some linux directory choosers (Nautilus) don't let you navigate directories
+            # by clicking them and show they greyed them out when FileMode.Directory is set
             # TODO: Check whether to use native or qt file chooser
-            dialog.setOption(QFileDialog.DontUseNativeDialog, True)
+            dialog.setOption(QFileDialog.Option.DontUseNativeDialog, True)
         return dialog
 
     def get_directory(self) -> Optional[str]:


### PR DESCRIPTION
This PR make the add-on compatible with Qt6 without using Anki's backwards compatibility mechanisms. (It can be disabled by setting the environment variable `DISABLE_QT5_COMPAT` to 1.)

I made it so that the non-native QFileDialog is used in Linux, because there were some problems with the native file dialog on my machine.

I also adds the submodules to git.