### PR TITLE
gdrive download folder as zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ meta.json
 google_api_key.py
 
 src/media_import/libs/
-src/media_import/temp/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ meta.json
 google_api_key.py
 
 src/media_import/libs/
+src/media_import/temp/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+git+https://github.com/andrewsanchez/pytest-anki.git@anki-2.1.54-qt5

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,17 @@
-from aqt import gui_hooks
+from aqt import gui_hooks, mw
+from typing import Callable
+from aqt.qt import QMenu, QAction
 
-from .anking import setupMenu
+
+from .anking import get_anking_menu
 from .media_import import open_import_dialog
+
+
+def setupMenu(handler: Callable[[], None]) -> None:
+    menu = get_anking_menu()
+    a = QAction("Import Media", mw)
+    a.triggered.connect(handler)  # type: ignore
+    menu.addAction(a)
 
 
 gui_hooks.main_window_did_init.append(lambda: setupMenu(open_import_dialog))

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,7 @@
-from aqt import gui_hooks, mw
 from typing import Callable
-from aqt.qt import QMenu, QAction
 
+from aqt import gui_hooks, mw
+from aqt.qt import QAction
 
 from .anking import get_anking_menu
 from .media_import import open_import_dialog

--- a/src/anking.py
+++ b/src/anking.py
@@ -1,7 +1,6 @@
 from aqt import mw
+from aqt.qt import QAction, QMenu
 from aqt.utils import openLink
-from aqt.qt import QMenu, QAction
-
 
 # fmt: off
 addon_name = __name__.split('.')[0]

--- a/src/anking.py
+++ b/src/anking.py
@@ -1,78 +1,74 @@
-from typing import Callable
 from aqt import mw
 from aqt.utils import openLink
-from aqt.qt import QAction, QMenu
+from aqt.qt import QMenu, QAction
+
+
+# fmt: off
+addon_name = __name__.split('.')[0]
+
+# Increment this after modifying below options.
+SUBMENU_VER = 2
+MENU_NAME = "&AnKing"
+
+GET_HELP_MENU_NAME = "Get Anki Help"
+GET_HELP_MENU_OPTIONS = [
+    ("Online Mastery Course", f"https://courses.ankipalace.com/?utm_source={addon_name}&utm_medium=anki_add-on&utm_campaign=mastery_course"),
+    ("Daily Q and A Support", "https://www.ankipalace.com/memberships"),
+    ("1-on-1 Tutoring", "https://www.ankipalace.com/tutoring"),
+]
+# fmt: on
 
 
 def create_get_help_submenu(parent: QMenu) -> QMenu:
-    submenu_name = "Get Anki Help"
-    menu_options = [
-        (
-            "Online Mastery Course",
-            "https://courses.ankipalace.com/?utm_source=anking_bg_add-on&utm_medium=anki_add-on&utm_campaign=mastery_course",
-        ),
-        ("Daily Q and A Support", "https://www.ankipalace.com/memberships"),
-        ("1-on-1 Tutoring", "https://www.ankipalace.com/tutoring"),
-    ]
-    submenu = QMenu(submenu_name, parent)
-    for name, url in menu_options:
+    submenu = QMenu(GET_HELP_MENU_NAME, parent)
+    for name, url in GET_HELP_MENU_OPTIONS:
         act = QAction(name, mw)
-        act.triggered.connect(lambda _, u=url: openLink(u)) # type: ignore
+        act.triggered.connect(lambda _, u=url: openLink(u))
         submenu.addAction(act)
     return submenu
 
 
 def maybe_add_get_help_submenu(menu: QMenu) -> None:
-    """Adds 'Get Anki Help' submenu in 'Anking' menu if needed.
-
+    """Adds submenu in 'Anking' menu if needed.
     The submenu is added if:
-     - The submenu does not exist in menu
-     - The submenu is an outdated version - existing is deleted
-
+    - The submenu does not exist in menu
+    - The submenu is an outdated version - existing is deleted
     With versioning and anking_get_help property,
     future version can rename, hide, or change contents in the submenu
     """
     submenu_property = "anking_get_help"
-    submenu_ver = 2
     for act in menu.actions():
+        # Don't replace below with GET_HELP_MENU_NAME
+        # so the menu name can be changed in the future.
+        # This is for older anking addons that doesn't set submenu_property
         if act.property(submenu_property) or act.text() == "Get Anki Help":
             ver = act.property("version")
-            if ver and ver >= submenu_ver:
+            if ver and ver >= SUBMENU_VER:
                 return
             submenu = create_get_help_submenu(menu)
             menu.insertMenu(act, submenu)
             menu.removeAction(act)
             new_act = submenu.menuAction()
             new_act.setProperty(submenu_property, True)
-            new_act.setProperty("version", submenu_ver)
+            new_act.setProperty("version", SUBMENU_VER)
             return
     else:
         submenu = create_get_help_submenu(menu)
         menu.addMenu(submenu)
         new_act = submenu.menuAction()
         new_act.setProperty(submenu_property, True)
-        new_act.setProperty("version", submenu_ver)
+        new_act.setProperty("version", SUBMENU_VER)
 
 
 def get_anking_menu() -> QMenu:
-    """Return AnKing menu. If it doesn't exist, create one. Make sure its submenus are up to date."""
+    """Get or create AnKing menu. Make sure its submenus are up to date."""
     menu_name = "&AnKing"
     menubar = mw.form.menubar
     for a in menubar.actions():
         if menu_name == a.text():
-            menu = a.menu()
+            menu = a.parent()
             break
     else:
         menu = menubar.addMenu(menu_name)
     maybe_add_get_help_submenu(menu)
     return menu
-
-
-########################################
-
-
-def setupMenu(handler: Callable[[], None]) -> None:
-    menu = get_anking_menu()
-    a = QAction("Import Media", mw)
-    a.triggered.connect(handler) # type: ignore
-    menu.addAction(a)

--- a/src/media_import/importing.py
+++ b/src/media_import/importing.py
@@ -266,7 +266,7 @@ def _import_media(
             raise err
 
     if isinstance(src, GDriveRoot):
-        gdrive.download_folder_zip(src.id, on_import_done)
+        gdrive.download_folder_zip(src.id, finish_import)
     else:
         mw.taskman.run_in_background(task=import_files_list, on_done=on_import_done)
 

--- a/src/media_import/importing.py
+++ b/src/media_import/importing.py
@@ -265,7 +265,7 @@ def _import_media(
         except Exception as err:
             raise err
 
-    if isinstance(src, GDriveRoot):
+    if isinstance(src, GDriveRoot) and len(files_list) > 5:
         gdrive.download_folder_zip(src.id, finish_import)
     else:
         mw.taskman.run_in_background(task=import_files_list, on_done=on_import_done)

--- a/src/media_import/importing.py
+++ b/src/media_import/importing.py
@@ -1,24 +1,20 @@
-from concurrent.futures import Future
-from typing import (
-    Callable,
-    Dict,
-    List,
-    NamedTuple,
-    Sequence,
-    NamedTuple,
-    Tuple,
-)
-from requests.exceptions import RequestException
-from datetime import datetime, timedelta
-import unicodedata
 import traceback
+import unicodedata
+from concurrent.futures import Future
+from datetime import datetime, timedelta
+from typing import Callable, Dict, List, NamedTuple, Sequence, Tuple
 
 from anki.media import media_paths_from_col_path
 from aqt import mw
 from aqt.utils import askUserDialog
-from .pathlike.gdrive import GDriveRoot, gdrive
-from .pathlike import FileLike, RootPath, LocalRoot
+from requests.exceptions import RequestException
+
+from .pathlike import FileLike, LocalRoot, RootPath
 from .pathlike.errors import AddonError
+from .pathlike.gdrive import GDriveRoot, gdrive
+
+# if there are at least so many files in a gdrive directory, it will be downloaded as a zip file
+GDRIVE_DOWNLOAD_AS_ZIP_THRESHOLD = 5
 
 
 class ImportResult(NamedTuple):
@@ -265,7 +261,10 @@ def _import_media(
         except Exception as err:
             raise err
 
-    if isinstance(src, GDriveRoot) and len(files_list) > 5:
+    if (
+        isinstance(src, GDriveRoot)
+        and len(files_list) > GDRIVE_DOWNLOAD_AS_ZIP_THRESHOLD
+    ):
         gdrive.download_folder_zip(src.id, finish_import)
     else:
         mw.taskman.run_in_background(task=import_files_list, on_done=on_import_done)

--- a/src/media_import/importing.py
+++ b/src/media_import/importing.py
@@ -16,7 +16,7 @@ import traceback
 from anki.media import media_paths_from_col_path
 from aqt import mw
 from aqt.utils import askUserDialog
-
+from .pathlike.gdrive import GDriveRoot, gdrive
 from .pathlike import FileLike, RootPath, LocalRoot
 from .pathlike.errors import AddonError
 
@@ -265,7 +265,10 @@ def _import_media(
         except Exception as err:
             raise err
 
-    mw.taskman.run_in_background(task=import_files_list, on_done=on_import_done)
+    if isinstance(src, GDriveRoot):
+        gdrive.download_folder_zip(src.id, on_import_done)
+    else:
+        mw.taskman.run_in_background(task=import_files_list, on_done=on_import_done)
 
 
 def find_unnormalized_name(files: Sequence[FileLike]) -> List[FileLike]:

--- a/src/media_import/pathlike/gdrive.py
+++ b/src/media_import/pathlike/gdrive.py
@@ -253,7 +253,7 @@ class FolderAsZipImporter:
 
     def on_finish_download_zip(self, future: Future) -> None:
         self.web.setParent(None)
-        self.web.page().profile().deleteLater()
+        self.web.page().deleteLater()
         self.web.deleteLater()
         self.web = None
 

--- a/src/media_import/pathlike/gdrive.py
+++ b/src/media_import/pathlike/gdrive.py
@@ -212,7 +212,6 @@ class FolderAsZipImporter:
         req.accept()
 
     def on_cmd(self, cmd: str):
-        print(cmd)
         if cmd.startswith("gdriveError!"):
             self.error_msg = cmd[len("gdriveError!") :]
 

--- a/src/media_import/pathlike/gdrive.py
+++ b/src/media_import/pathlike/gdrive.py
@@ -190,16 +190,17 @@ class FolderAsZipImporter:
                     if (elem) {
                         elem.dispatchEvent(new MouseEvent("mousedown"));elem.dispatchEvent(new MouseEvent("mouseup"));elem.dispatchEvent(new MouseEvent("click")); 
                     } else {
-                        setTimeout(onload, 1000);
+                        setTimeout(onload, 2000);
                     }
                 } catch (e) {
-                    pycmd("gdriveError!" + e.toString())
+                    pycmd("gdriveError!" + e.toString());
                 }
             }
+            // There seems to be some delay between document load and event listener attaching
             if (document.readyState === "complete") {
-                onload()
+                setTimeout(onload, 5000);
             } else {
-                window.addEventListener("load", setTimeout(onload, 3000))
+                window.addEventListener("load", setTimeout(onload, 5000));
             }
         })()
             """

--- a/src/media_import/pathlike/gdrive.py
+++ b/src/media_import/pathlike/gdrive.py
@@ -276,8 +276,9 @@ class FolderAsZipImporter:
             root = LocalRoot(inner_dir.path)
             import_media(root, self.on_finish)
 
+    # TODO: refactor logs mechanism and progress dialog
     def on_finish(self, result: "ImportResult") -> None:
-        self.on_done("\n".join(result.logs), result.success)
+        self.on_done("Successfully imported media files", result.success)
 
 
 gdrive = GDrive()

--- a/src/media_import/pathlike/gdrive.py
+++ b/src/media_import/pathlike/gdrive.py
@@ -200,7 +200,7 @@ class FolderAsZipImporter:
             if (document.readyState === "complete") {
                 setTimeout(onload, 5000);
             } else {
-                window.addEventListener("load", setTimeout(onload, 5000));
+                window.addEventListener("load", () => {setTimeout(onload, 5000)});
             }
         })()
             """

--- a/src/media_import/pathlike/gdrive.py
+++ b/src/media_import/pathlike/gdrive.py
@@ -1,5 +1,6 @@
 from concurrent.futures import Future
 from pathlib import Path
+import time
 from typing import List, Callable, Any
 import requests
 import re
@@ -29,6 +30,9 @@ except:  # Not production?
         API_KEY = os.environ["GOOGLE_API_KEY"]
     except:
         API_KEY = None
+
+
+ZIP_DOWNLOAD_PATH = Path(__file__).resolve().parent.parent / "temp"
 
 
 class PrivateWebPage(AnkiWebPage):
@@ -106,7 +110,7 @@ class GDrive:
         profile = QWebEngineProfile()
         dialog.profile = profile
         profile.setHttpAcceptLanguage("en")
-        profile.setDownloadPath(str(Path().parent.resolve()))
+        profile.setDownloadPath(str(ZIP_DOWNLOAD_PATH))
         # qt6: QWebEngineDownloadRequest, qt5: QWebEngineDownloadItem
         request = None
         isError = False
@@ -157,11 +161,14 @@ class GDrive:
 
         def _download_folder_zip(id: str):
             while True:
+                time.sleep(0.5)
                 if request is None:
                     continue
                 if request.isFinished():
-                    return
-                return
+                    return (True, "Finished")
+                if mw.progress.want_cancel():
+                    request.cancel()
+                    return (False, "Cancelled")
                 mw.taskman.run_on_main(
                     lambda: mw.progress.update(
                         label="Downloading folder",

--- a/src/media_import/pathlike/gdrive.py
+++ b/src/media_import/pathlike/gdrive.py
@@ -113,7 +113,7 @@ class GDrive:
         profile.setDownloadPath(str(ZIP_DOWNLOAD_PATH))
         # qt6: QWebEngineDownloadRequest, qt5: QWebEngineDownloadItem
         request = None
-        isError = False
+        errorMsg: Optional[str] = None
 
         def onDownload(req: Any):
             nonlocal request
@@ -122,10 +122,10 @@ class GDrive:
             req.accept()
 
         def onCmd(cmd: str):
-            nonlocal isError
-            if cmd == "gdriveError":
-                isError = True
+            nonlocal errorMsg
             print(cmd)
+            if cmd.startswith("gdriveError!"):
+                errorMsg = cmd[len("gdriveError!") :]
 
         profile.downloadRequested.connect(onDownload)
         backgroundColor = web.page().backgroundColor()
@@ -140,24 +140,26 @@ class GDrive:
         (() => {
             const onload = () => {
                 try {
-                    pycmd("start")
                     const elem = document.evaluate("//div[text()='Download all']", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE).singleNodeValue;
+                    if (elem) {
+                        elem.dispatchEvent(new MouseEvent("mousedown"));elem.dispatchEvent(new MouseEvent("mouseup"));elem.dispatchEvent(new MouseEvent("click")); 
                     elem.dispatchEvent(new MouseEvent("mousedown"));elem.dispatchEvent(new MouseEvent("mouseup"));elem.dispatchEvent(new MouseEvent("click")); 
-                    pycmd("dispatched")
+                        elem.dispatchEvent(new MouseEvent("mousedown"));elem.dispatchEvent(new MouseEvent("mouseup"));elem.dispatchEvent(new MouseEvent("click")); 
+                    } else {
+                        setTimeout(onload, 1000);
+                    }
                 } catch (e) {
-                    pycmd("gdriveError")
+                    pycmd("gdriveError!" + e.toString())
                 }
             }
             if (document.readyState === "complete") {
                 onload()
             } else {
-                window.addEventListener("load", () => setTimeout(() => {onload()}, 5000))
+                window.addEventListener("load", setTimeout(onload, 3000))
             }
-            pycmd("Evaluated")
         })()
             """
         )
-        print("Load finished")
 
         def _download_folder_zip(id: str):
             while True:

--- a/tests/test_importing.py
+++ b/tests/test_importing.py
@@ -30,6 +30,25 @@ def test_gdrive_import(anki_session: AnkiSession) -> None:
         _test_import(root, mw)
 
 
+def test_gdrive_as_folder_import(anki_session: AnkiSession, monkeypatch) -> None:
+    # does not work yet, the js here:
+    # https://github.com/ankipalace/anki-media-import/blob/7bf9cfb1d99da9eed3654ee8586e4a3cad0fa899/src/media_import/pathlike/gdrive.py#L176
+    # is never executed
+
+    with anki_session.profile_loaded():
+        from src.media_import.pathlike.gdrive import GDriveRoot
+
+        monkeypatch.setattr(
+            "src.media_import.importing.GDRIVE_DOWNLOAD_AS_ZIP_THRESHOLD", 0
+        )
+
+        root = GDriveRoot(
+            "https://drive.google.com/drive/folders/1goqb4kHJHhxw4NASSd4vXMp6h04bansc"
+        )
+        mw = anki_session.mw
+        _test_import(root, mw)
+
+
 def test_mega_import(anki_session: AnkiSession) -> None:
 
     with anki_session.profile_loaded():


### PR DESCRIPTION
Turns out you *can* download the zipped folder. Got it to work in a very rough way. 

Basically, the add-on will secretly open the google drive link in its web browser and click the 'Download all' button. Then on completion unzip the folder and use local folder importer.

I investigated using the api (google takeout api), but it's not exposed to the public and you need the internal google api key for that. I think it *is* possible to scrape their api key from the html, but this way seems easier and less tos-breaking.

#4