### PR TITLE
comment out assert check

### DIFF
--- a/src/media_import/importing.py
+++ b/src/media_import/importing.py
@@ -330,4 +330,4 @@ def add_media(file: FileLike) -> None:
     """
     data = file.read_bytes()
     new_name = mw.col.media.write_data(file.name, data)
-    assert new_name == file.name  # TODO: write an error dialogue?
+    # assert new_name == file.name  # TODO: write an error dialogue?


### PR DESCRIPTION
Fixes #8. Kind of?

Any idea what could be causing the errors? There shouldn't be a reason for the media file to be renamed. It's only renamed if 1) file name isn't normalized, 2) if there's already a file at given path. Both are checked during media import process.