### PR TITLE
fix: Truncate file name list in message

### DIFF
--- a/src/media_import/importing.py
+++ b/src/media_import/importing.py
@@ -175,9 +175,11 @@ def _import_media(
     if len(name_conflicts):
         msg = f"{len(name_conflicts)} files have the same name as existing media files:"
         log(msg)
+        name_conflict_truncated = name_conflicts[:10]
         file_names_str = ""
-        for file in name_conflicts:
+        for file in name_conflict_truncated:
             file_names_str += file.name + "\n"
+        file_names_str += "...\n" if len(name_conflicts) > 10 else ""
         log(file_names_str + "-" * 16)
         ask_msg = msg + "\nDo you want to import the rest of the files?"
         mw.progress.finish()  # Close progress window for askUserDialog


### PR DESCRIPTION
Currently, when there are file name conflicts, the whole file list is shown on a dialog. This looks bad. This PR fixes the problem by truncating the file list to 10 elements at most.

<img src="https://github.com/ankipalace/anki-media-import/assets/31575114/0cdc7e58-6016-46cf-8329-104aa25a6a60" width="300" />

Report: https://community.ankihub.net/t/anking-v12-media-not-importing/3657.
